### PR TITLE
[UI 수정] 메인페이지 높이 수정 및 전체 레이아웃 수정

### DIFF
--- a/src/features/main/ui/section/FriendListSection.tsx
+++ b/src/features/main/ui/section/FriendListSection.tsx
@@ -65,6 +65,7 @@ const FriendListContainer = styled.div`
   gap: 1rem;
   width: 100%;
   padding: 10px 0;
+  justify-items: center;
 `;
 
 const FriendListCard = styled.div`

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -5,7 +5,6 @@ import {
   FriendListSection,
   RecentClipSection,
 } from '@/features';
-import { HEADER_HEIGHT, NavigateBarHeight } from '@/shared';
 
 export default function MainPage() {
   return (
@@ -22,8 +21,6 @@ const MainPageLayout = styled.div`
   flex-direction: column;
   padding: 0 1rem;
   width: 100%;
-  height: calc(100dvh - ${HEADER_HEIGHT}px);
   align-items: center;
   justify-content: center;
-  margin-bottom: calc(${NavigateBarHeight}px + 2rem);
 `;

--- a/src/widgets/layout/Layout.tsx
+++ b/src/widgets/layout/Layout.tsx
@@ -2,7 +2,13 @@ import { Outlet } from 'react-router-dom';
 
 import styled from '@emotion/styled';
 
-import { HEADER_HEIGHT, Header, NavigateBar, ScrollToTop } from '@/shared';
+import {
+  HEADER_HEIGHT,
+  Header,
+  NavigateBar,
+  NavigateBarHeight,
+  ScrollToTop,
+} from '@/shared';
 
 export const Layout = () => {
   return (
@@ -29,6 +35,7 @@ const PageContainer = styled.div`
   top: 0;
   left: 0;
   margin-top: ${HEADER_HEIGHT}px;
+  padding-bottom: ${NavigateBarHeight}px;
   width: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 📝 상세 내용
- 화면 상단에 글자가 겹쳐서 보이는 현상 수정
- 친구 목록이 왼쪽으로 치우쳐져 보이는 현상 수정

## #️⃣ 이슈 번호

- #26 

## ⏰ 현재 버그
x

## 📷 스크린샷(선택)
<img width="1228" alt="스크린샷 2025-07-08 오후 10 29 18" src="https://github.com/user-attachments/assets/9de04e75-4f87-4f14-b952-e49810f9adc1" />

