### PR TITLE
토큰 관리 방식 변경 및 토큰 재발급 기능 추가

### DIFF
--- a/src/app/routes/components/AuthRoute.tsx
+++ b/src/app/routes/components/AuthRoute.tsx
@@ -5,7 +5,7 @@ import { ROUTER_PATH, useAuthStore } from '@/shared';
 
 export const AuthRoute = () => {
   const navigate = useNavigate();
-  const isLoggedIn = useAuthStore((state) => state.nickname);
+  const isLoggedIn = useAuthStore((state) => state.accessToken);
 
   useEffect(() => {
     if (!isLoggedIn) {

--- a/src/app/routes/components/AuthRoute.tsx
+++ b/src/app/routes/components/AuthRoute.tsx
@@ -1,19 +1,9 @@
-import { useEffect } from 'react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router-dom';
 
 import { ROUTER_PATH, useAuthStore } from '@/shared';
 
 export const AuthRoute = () => {
-  const navigate = useNavigate();
   const isLoggedIn = useAuthStore((state) => state.accessToken);
 
-  useEffect(() => {
-    if (!isLoggedIn) {
-      navigate(ROUTER_PATH.LOGIN);
-    }
-  }, [isLoggedIn, navigate]);
-
-  if (!isLoggedIn) return null;
-
-  return <Outlet />;
+  return isLoggedIn ? <Outlet /> : <Navigate to={ROUTER_PATH.LOGIN} replace />;
 };

--- a/src/entities/auth/apis/login.api.ts
+++ b/src/entities/auth/apis/login.api.ts
@@ -8,6 +8,7 @@ interface LoginAPIRequest {
 }
 
 export interface LoginResponse {
+  accessToken: string;
   nickname: string;
   message: string;
   provider: string;

--- a/src/entities/auth/ui/form/LoginForm.tsx
+++ b/src/entities/auth/ui/form/LoginForm.tsx
@@ -6,14 +6,21 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { Button, Form, ROUTER_PATH, useAuthStore } from '@/shared';
+import {
+  Button,
+  Form,
+  ROUTER_PATH,
+  useAuthStore,
+  useNicknameStore,
+} from '@/shared';
 
 import { type LoginResponse, loginAPI } from '../../apis';
 import { type LoginSchemaType, loginSchema } from '../../model';
 import { PasswordField, UserIdField } from '../components';
 
 export const LoginForm = () => {
-  const { setNickname } = useAuthStore();
+  const { setNickname } = useNicknameStore();
+  const { setAccessToken } = useAuthStore();
 
   const navigate = useNavigate();
 
@@ -29,6 +36,7 @@ export const LoginForm = () => {
     toast.success('로그인 성공!');
 
     setNickname(data.nickname);
+    setAccessToken(data.accessToken);
 
     navigate(ROUTER_PATH.MAIN);
     form.reset();

--- a/src/shared/apis/index.ts
+++ b/src/shared/apis/index.ts
@@ -1,0 +1,1 @@
+export * from './reissue.api';

--- a/src/shared/apis/reissue.api.ts
+++ b/src/shared/apis/reissue.api.ts
@@ -1,0 +1,15 @@
+import { type ApiResponse, fetchInstance, processApiResponse } from '@/shared';
+
+export const REISSUE_API_PATH = '/api/auth/reissue';
+
+export interface ReissueResponse {
+  newAccessToken: string;
+  message: string;
+}
+
+export const reissueApi = async (): Promise<ReissueResponse> => {
+  const response =
+    await fetchInstance.post<ApiResponse<ReissueResponse>>(REISSUE_API_PATH);
+
+  return processApiResponse(response.data);
+};

--- a/src/shared/config/auth-error.ts
+++ b/src/shared/config/auth-error.ts
@@ -67,8 +67,8 @@ export const authErrorInterceptor = async (error: AxiosError) => {
         }
       })
         .then((token) => {
-          if (token && originalRequest) {
-            originalRequest.headers['Authorization'] = `${token}`;
+          if (token && originalRequest?.headers) {
+            originalRequest.headers['Authorization'] = `Bearer ${token}`;
             return fetchInstance(originalRequest);
           }
         })

--- a/src/shared/config/auth-error.ts
+++ b/src/shared/config/auth-error.ts
@@ -1,0 +1,82 @@
+import { AxiosError } from 'axios';
+
+import { reissueApi } from '../apis';
+import { ROUTER_PATH } from '../constants';
+import { fetchInstance } from '../libs';
+import { useAuthStore, useNicknameStore } from '../store';
+
+let isRefreshing = false;
+let failedQueue: {
+  resolve: (token: string | null) => void;
+  reject: (error: Error) => void;
+}[] = [];
+
+const clearAuthState = () => {
+  const { clearAccessToken } = useAuthStore.getState();
+  const { clearNickname } = useNicknameStore.getState();
+
+  clearAccessToken();
+  clearNickname();
+};
+
+const redirectToLogin = () => {
+  window.location.href = ROUTER_PATH.LOGIN;
+};
+
+const handleTokenRefreshFailure = async () => {
+  clearAuthState();
+  redirectToLogin();
+};
+
+const processQueue = (error: Error | null, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+export const authErrorInterceptor = async (error: AxiosError) => {
+  if (error.response) {
+    const status = error.response.status;
+    const originalRequest = error.config;
+
+    if (status === 401 && originalRequest) {
+      return new Promise((resolve, reject) => {
+        failedQueue.push({ resolve, reject });
+
+        if (!isRefreshing) {
+          isRefreshing = true;
+
+          reissueApi()
+            .then((response) => {
+              const { setAccessToken } = useAuthStore.getState();
+              setAccessToken(response.newAccessToken);
+              processQueue(null, response.newAccessToken);
+            })
+            .catch(async (reissueError) => {
+              await handleTokenRefreshFailure();
+              processQueue(reissueError, null);
+            })
+            .finally(() => {
+              isRefreshing = false;
+            });
+        }
+      })
+        .then((token) => {
+          if (token && originalRequest) {
+            originalRequest.headers['Authorization'] = `${token}`;
+            return fetchInstance(originalRequest);
+          }
+        })
+        .catch((queueError) => {
+          return Promise.reject(queueError);
+        });
+    }
+  }
+
+  return Promise.reject(error);
+};

--- a/src/shared/config/auth-error.ts
+++ b/src/shared/config/auth-error.ts
@@ -71,6 +71,7 @@ export const authErrorInterceptor = async (error: AxiosError) => {
             originalRequest.headers['Authorization'] = `Bearer ${token}`;
             return fetchInstance(originalRequest);
           }
+          return Promise.reject(error);
         })
         .catch((queueError) => {
           return Promise.reject(queueError);

--- a/src/shared/config/http-error.ts
+++ b/src/shared/config/http-error.ts
@@ -1,7 +1,7 @@
 import type { AxiosError } from 'axios';
 
 import { ROUTER_PATH } from '../constants';
-import { useAuthStore } from '../store';
+import { useAuthStore, useNicknameStore } from '../store';
 
 // 에러 정보 타입
 export interface ErrorInfo {
@@ -12,11 +12,12 @@ export interface ErrorInfo {
 
 // 401 에러 특별 처리 (로그인 페이지 리다이렉트)
 const getUnauthorizedError = (): ErrorInfo => {
-  const { clearNickname } = useAuthStore.getState();
+  const { clearNickname } = useNicknameStore.getState();
+  const { clearAccessToken } = useAuthStore.getState();
   clearNickname();
-
+  clearAccessToken();
   return {
-    message: '인증이 필요합니다.',
+    message: '로그인이 필요합니다.',
     shouldRedirect: true,
     redirectPath: ROUTER_PATH.LOGIN,
   };

--- a/src/shared/config/http-error.ts
+++ b/src/shared/config/http-error.ts
@@ -1,8 +1,5 @@
 import type { AxiosError } from 'axios';
 
-import { ROUTER_PATH } from '../constants';
-import { useAuthStore, useNicknameStore } from '../store';
-
 // 에러 정보 타입
 export interface ErrorInfo {
   message: string;
@@ -10,25 +7,9 @@ export interface ErrorInfo {
   redirectPath?: string;
 }
 
-// 401 에러 특별 처리 (로그인 페이지 리다이렉트)
-const getUnauthorizedError = (): ErrorInfo => {
-  const { clearNickname } = useNicknameStore.getState();
-  const { clearAccessToken } = useAuthStore.getState();
-  clearNickname();
-  clearAccessToken();
-  return {
-    message: '로그인이 필요합니다.',
-    shouldRedirect: true,
-    redirectPath: ROUTER_PATH.LOGIN,
-  };
-};
-
 // HTTP 상태 코드별 에러 처리 함수
-const getHttpErrorByStatus = (status: number): ErrorInfo => {
-  if (status === 401) {
-    return getUnauthorizedError();
-  }
-
+const getHttpErrorByStatus = (): ErrorInfo => {
+  // 401 에러는 authErrorInterceptor에서 독점적으로 처리됨
   // HTTP 에러는 사용자에게 보여주지 않음
   return {
     message: '요청을 처리할 수 없습니다.',
@@ -40,7 +21,7 @@ export const processHttpError = (error: AxiosError): ErrorInfo => {
   // HTTP 상태 코드별 에러 처리
   const status = error.response?.status;
   if (status) {
-    return getHttpErrorByStatus(status);
+    return getHttpErrorByStatus();
   } else {
     // 네트워크 에러 등 기타 에러
     return {

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -1,1 +1,2 @@
+export * from './auth-error';
 export * from './http-error';

--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -1,1 +1,2 @@
 export * from './useAuth';
+export * from './useNickname';

--- a/src/shared/store/useAuth.ts
+++ b/src/shared/store/useAuth.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 // accessToken을 메모리에서만 관리하는 store
 type AccessTokenState = {
@@ -10,11 +11,18 @@ type AccessTokenActions = {
   clearAccessToken: () => void;
 };
 
-export const useAuthStore = create<AccessTokenState & AccessTokenActions>(
-  (set) => ({
-    accessToken: null,
+export const useAuthStore = create<AccessTokenState & AccessTokenActions>()(
+  devtools(
+    (set) => ({
+      accessToken: null,
 
-    setAccessToken: (accessToken) => set({ accessToken }),
-    clearAccessToken: () => set({ accessToken: null }),
-  }),
+      setAccessToken: (accessToken) =>
+        set({ accessToken }, false, 'setAccessToken'),
+      clearAccessToken: () =>
+        set({ accessToken: null }, false, 'clearAccessToken'),
+    }),
+    {
+      name: 'auth-store', // Redux DevTools에서 표시될 스토어 이름
+    },
+  ),
 );

--- a/src/shared/store/useAuth.ts
+++ b/src/shared/store/useAuth.ts
@@ -1,26 +1,20 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
-import type { User } from '../types';
-
-// User type에서 nickname만 가져와서 사용
-type NicknameState = Partial<Pick<User, 'nickname'>>;
-
-type NicknameActions = {
-  setNickname: (nickname: string) => void;
-  clearNickname: () => void;
+// accessToken을 메모리에서만 관리하는 store
+type AccessTokenState = {
+  accessToken: string | null;
 };
 
-export const useAuthStore = create(
-  persist<NicknameState & NicknameActions>(
-    (set) => ({
-      nickname: undefined,
+type AccessTokenActions = {
+  setAccessToken: (token: string) => void;
+  clearAccessToken: () => void;
+};
 
-      setNickname: (nickname) => set({ nickname }),
-      clearNickname: () => set({ nickname: undefined }),
-    }),
-    {
-      name: 'nickname',
-    },
-  ),
+export const useAuthStore = create<AccessTokenState & AccessTokenActions>(
+  (set) => ({
+    accessToken: null,
+
+    setAccessToken: (accessToken) => set({ accessToken }),
+    clearAccessToken: () => set({ accessToken: null }),
+  }),
 );

--- a/src/shared/store/useAuth.ts
+++ b/src/shared/store/useAuth.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 
-// accessToken을 메모리에서만 관리하는 store
+// accessToken을 localStorage에서 관리하는 store
 type AccessTokenState = {
   accessToken: string | null;
 };
@@ -13,14 +13,19 @@ type AccessTokenActions = {
 
 export const useAuthStore = create<AccessTokenState & AccessTokenActions>()(
   devtools(
-    (set) => ({
-      accessToken: null,
+    persist(
+      (set) => ({
+        accessToken: null,
 
-      setAccessToken: (accessToken) =>
-        set({ accessToken }, false, 'setAccessToken'),
-      clearAccessToken: () =>
-        set({ accessToken: null }, false, 'clearAccessToken'),
-    }),
+        setAccessToken: (accessToken) =>
+          set({ accessToken }, false, 'setAccessToken'),
+        clearAccessToken: () =>
+          set({ accessToken: null }, false, 'clearAccessToken'),
+      }),
+      {
+        name: 'accessToken', // localStorage에 저장될 키 이름
+      },
+    ),
     {
       name: 'auth-store', // Redux DevTools에서 표시될 스토어 이름
     },

--- a/src/shared/store/useNickname.ts
+++ b/src/shared/store/useNickname.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import type { User } from '../types';
+
+// User type에서 nickname만 가져와서 사용
+type NicknameState = Partial<Pick<User, 'nickname'>>;
+
+type NicknameActions = {
+  setNickname: (nickname: string) => void;
+  clearNickname: () => void;
+};
+
+// nickname을 localStorage에 저장하는 store
+export const useNicknameStore = create(
+  persist<NicknameState & NicknameActions>(
+    (set) => ({
+      nickname: undefined,
+
+      setNickname: (nickname) => set({ nickname }),
+      clearNickname: () => set({ nickname: undefined }),
+    }),
+    {
+      name: 'nickname',
+    },
+  ),
+);


### PR DESCRIPTION
## 📝 요약 (Summary)
> 블로그 정리 글 : [효율적인 토큰 관리 방법](https://velog.io/@dobby_min/%ED%9A%A8%EC%9C%A8%EC%A0%81%EC%9D%B8-%ED%86%A0%ED%81%B0-%EA%B4%80%EB%A6%AC-%EB%B0%A9%EB%B2%95)

서버의 토큰 관리 방식 변경에 따라, 클라이언트의 **인증 아키텍처를 전면 재설계**했습니다.

**`AccessToken`은 메모리(Zustand)에, `RefreshToken`은 `HttpOnly` 쿠키**에 저장하는 현대적인 표준 방식을 도입하여, 보안을 유지하면서 클라이언트가 로그인 상태를 즉시 인지할 수 있도록 개선했습니다. 

또한, 이를 기반으로 **인증된 사용자만 접근할 수 있는 보호된 라우트(Protected Route) 기능을 구현**했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- 서버 API 변경에 맞춰 클라이언트 토큰 관리 전략 수정
- `Zustand` 스토어를 이용해 `AccessToken`을 메모리에 저장 및 관리
-  `zustand/middleware/devtools`를 적용하여 Redux DevTools와 연동
- `AccessToken` 유무에 따라 페이지 접근을 제어하는 `AuthRoute` 컴포넌트 구현
- `reissue` API를 활용한 자동 토큰 재발급(Silent Refresh) 로직의 기반 마련

## 💻 상세 구현 내용 (Implementation Details)

### 🤔 왜 인증 아키텍처를 변경해야 했는가?

**문제점**: 기존 방식은 `AccessToken`과 `RefreshToken`을 모두 `HttpOnly` 쿠키에 저장했습니다. 이 방식은 XSS 공격으로부터 토큰을 안전하게 보호하지만, 클라이언트의 JavaScript가 토큰의 존재 여부를 알 수 없다는 치명적인 단점이 있었습니다. 

이 때문에 클라이언트는 사용자의 로그인 상태를 즉시 판단할 수 없어, API 요청이 실패한 후에야 비로소 로그아웃 상태임을 인지하는 등 비효율적이고 좋지 않은 사용자 경험을 유발했습니다.

**해결**: 서버와의 협의를 통해, `RefreshToken`은 보안을 위해 `HttpOnly` 쿠키에 유지하되, **`AccessToken`은 로그인 시 응답 본문(body)으로 직접 전달받는 방식**으로 변경했습니다.

### ✨ 새로운 토큰 관리 전략 및 `AuthRoute`

클라이언트는 전달받은 `AccessToken`을 `localStorage`가 아닌 **`Zustand` 스토어, 즉 메모리에 저장**합니다.

- **보안 강화**: `localStorage`는 XSS 공격에 취약하지만, 메모리에 저장된 `AccessToken`은 페이지를 새로고침하면 사라지므로 토큰 탈취 시 피해를 최소화할 수 있습니다.
- **상태 기반 라우팅**: `useAuthStore`에 저장된 `AccessToken`의 유무를 "로그인 상태"의 기준으로 삼아, 인증이 필요한 페이지를 보호하는 `AuthRoute`를 구현했습니다.

```tsx
import { Navigate, Outlet } from 'react-router-dom';

import { ROUTER_PATH, useAuthStore } from '@/shared';

export const AuthRoute = () => {
  const isLoggedIn = useAuthStore((state) => state.accessToken);

  return isLoggedIn ? <Outlet /> : <Navigate to={ROUTER_PATH.LOGIN} replace />;
};
```

이러한 구조는 **'조용한 재발급(Silent Refresh)'** 메커니즘을 통해 완성됩니다. 페이지를 새로고침하면 메모리의 `AccessToken`은 사라지지만, 앱이 로딩될 때 `reissue` API를 호출하여 `RefreshToken` 쿠키를 통해 새로운 `AccessToken`을 발급받아 로그인 상태를 복원합니다.

### 🔧 Zustand Devtools 연동을 통한 디버깅 경험 개선

### 🤔 왜 Devtools를 연동했는가?

`Zustand`는 상태를 메모리에 저장하기 때문에, `console.log`를 사용하지 않고는 `AccessToken`과 같은 상태가 현재 어떤 값을 가지고 있는지, 어떤 액션에 의해 변경되었는지 추적하기가 어렵습니다.

이러한 불편함을 해소하고 **디버깅 효율을 극대화**하기 위해, `zustand/middleware/devtools`를 사용하여 `useAuthStore`를 **Redux DevTools 브라우저 확장 프로그램**과 연동했습니다.

**결과**: 이제 Redux DevTools를 통해 **모든 상태 변경 내역을 시각적으로 추적**할 수 있습니다. 어떤 액션이 호출되었는지, 그로 인해 상태가 어떻게 변했는지(before/after) 한눈에 파악할 수 있으며, '시간 여행(Time-travel)' 디버깅까지 가능해져 개발 생산성이 크게 향상되었습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

현재 로그인 기능 자체는 정상적으로 동작하지만, **페이지 새로고침 시 '조용한 재발급'이 의도대로 동작하지 않는 문제**를 발견했습니다.

### 가설: API 요청 경합(Race Condition)으로 인한 재발급 로직 실패

- **현상**: 새로고침 직후, `AccessToken`이 메모리에 없는 상태에서 메인 페이지의 클립 데이터 API가 먼저 호출됩니다.
- **추측**: 이 API 요청이 `401` 에러를 발생시키고, 이 에러가 `axios` 인터셉터의 토큰 재발급 로직을 트리거하기 전에 다른 종류의 서버 에러(ex. 500)를 유발하여 재발급 프로세스 자체가 실행되지 못하는 것으로 추정됩니다. 결과적으로 클라이언트는 토큰이 없기 때문에 비로그인 상태로 판단하고 로그인 페이지로 리다이렉트합니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

위 트러블 슈팅에서 제기된 새로고침 시 토큰 재발급 실패 이슈는 현재 해결되지 않은 상태입니다. 로그인/로그아웃 기능 자체는 정상 동작하므로, 이 이슈는 다음 작업에서 아래와 같은 단계로 디버깅하여 해결할 예정입니다.

1. **가설 검증**: `AccessToken` 관리 방식을 `Zustand`(메모리)에서 `localStorage`로 일시 변경하여, 새로고침 시에도 토큰이 즉시 존재하는 환경을 만듭니다. 이 상태에서 API 요청이 정상적으로 동작하는지 확인합니다.
2. **원인 확정**: 만약 `localStorage` 방식에서 정상 동작한다면, 초기 API 요청과 토큰 재발급 요청 간의 경합(Race Condition)이 문제의 원인임이 확정됩니다.
3. **해결**: 앱 초기화 단계에서, 토큰 재발급 로직이 완료되기 전까지는 다른 API 요청이 발생하지 않도록 제어하는 로직(ex. 로딩 상태 플래그, 요청 지연 처리 등)을 추가하여 문제를 해결할 계획입니다.

## 📸 스크린샷 (Screenshots)

### zustand Store에 accessToken이 정상적으로 담겨있는 모습
<img width="1552" height="939" alt="스크린샷 2025-08-14 오후 1 52 31" src="https://github.com/user-attachments/assets/57802155-fd85-4bd2-9dc3-b39b4fdf6143" />


### 로그인 → 로그인 성공 → 새로고침 이후 까지의 흐름
https://github.com/user-attachments/assets/ec6b5746-f7f2-4706-8150-18c5da23af2e



## #️⃣ 관련 이슈 (Related Issues)

- #39